### PR TITLE
fix: restore no-arg /pr:review MCP prompt submission

### DIFF
--- a/src/server.ts
+++ b/src/server.ts
@@ -487,11 +487,11 @@ export class PRReviewMCPServer {
   private registerPrompts(): void {
     const client = this.githubClient;
 
-    // Shared Zod shape for review prompt arguments
+    // Shared prompt arguments for slash-command use.
+    // Keep this aligned with REVIEW_PROMPT_DEFINITION.arguments so Claude Code
+    // does not prompt for internal owner/repo values before submit.
     const reviewArgsSchema = {
-      owner: z.string().optional().describe('Repository owner'),
-      repo: z.string().optional().describe('Repository name'),
-      pr: z.string().optional().describe('PR number, GitHub URL, or short format (owner/repo#123)'),
+      pr: z.string().optional().describe('PR number, GitHub URL, or short format (owner/repo#123). Omit to process all open PRs.'),
       workers: z.string().optional().describe('Number of parallel workers (default: 3)'),
     };
 


### PR DESCRIPTION
## Summary

- hide internal `owner`/`repo` fields from the MCP prompt arg schema for `review`
- keep only user-facing `pr` and `workers` arguments on the slash-command surface
- preserve owner/repo inference from the current git remote and no-arg multi-PR mode

## Problem

Claude Code started converting `/pr:review` to `/mcp__pr__review` and then blocking submit waiting for parameters. The root cause was that the MCP prompt registration exposed `owner`, `repo`, `pr`, and `workers` in `argsSchema`, while the actual user-facing command contract only expects `pr` and `workers`.

## Test plan

- [x] `npm ci`
- [x] `npm run build`
- [x] `npx vitest run` (227/227)

## Summary by Sourcery

Align the /pr:review MCP prompt arguments with the user-facing slash-command so internal owner/repo fields are no longer exposed and no-arg multi-PR mode continues to work.

Bug Fixes:
- Stop MCP from blocking /pr:review submissions by hiding internal owner/repo fields from the prompt argument schema.

Enhancements:
- Clarify the PR argument description to document that omitting it processes all open PRs.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Заметки о выпуске

* **Изменения**
  * Обновлено поведение системы проверки кода: при отсутствии указания конкретного PR теперь будут обработаны все открытые PR.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->