### PR TITLE
feat: ship built-in pr-reviewer agent and canonical pr-review skill

### DIFF
--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "pr-review-mcp",
-  "version": "0.3.0",
+  "version": "0.6.0",
   "description": "Orchestrate AI-driven PR reviews at scale. Unified MCP interface for CodeRabbit, Gemini, Copilot, Sourcery, Qodo, Codex, and Greptile with parallel multi-agent coordination.",
   "author": {
     "name": "thebtf",

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -95,6 +95,7 @@ pr-review-mcp/
 │       └── SKILL.md           # Canonical consumer-facing PR review skill
 ├── commands/
 │   ├── review.md              # Prompt wrapper for /pr:review
+│   ├── review-background.md   # Prompt wrapper for /pr:review-background
 │   └── setup.md               # Prompt wrapper for /pr:setup
 └── dist/                      # Compiled output
 ```

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -2,7 +2,7 @@
 
 ## PURPOSE
 
-MCP server for orchestrating AI-driven PR reviews with 7 agent sources, 20 tools, and parallel multi-agent coordination.
+Plugin-first MCP package for orchestrating AI-driven PR reviews with 7 agent sources, 20 tools, and parallel multi-agent coordination.
 
 **Features:**
 - GraphQL-based GitHub integration with cursor pagination
@@ -10,6 +10,8 @@ MCP server for orchestrating AI-driven PR reviews with 7 agent sources, 20 tools
 - AI prompt extraction from review comments
 - Agent invocation + server-side review await (`pr_invoke` → `pr_await_reviews`)
 - Parallel worker orchestration for comment processing
+- Built-in prompt/command wrappers (`/pr:review`, `/pr:review-background`, `/pr:setup`)
+- Built-in background `pr-reviewer` agent and canonical `pr-review` skill
 
 ---
 
@@ -84,12 +86,16 @@ pr-review-mcp/
 │       ├── state.ts           # In-memory coordination state (CoordinationStateManager)
 │       ├── sqlite-state.ts    # SQLite-backed coordination state
 │       └── types.ts           # Coordination types
+├── agents/
+│   └── pr-reviewer.md         # Built-in background PR reviewer agent
 ├── skills/
-│   └── review/
-│       └── SKILL.md           # PR review skill (Claude Code plugin)
+│   ├── review/
+│   │   └── SKILL.md           # MCP-prompt-oriented review skill
+│   └── pr-review/
+│       └── SKILL.md           # Canonical consumer-facing PR review skill
 ├── commands/
-│   ├── review.md              # Legacy review command
-│   └── setup.md               # Setup command
+│   ├── review.md              # Prompt wrapper for /pr:review
+│   └── setup.md               # Prompt wrapper for /pr:setup
 └── dist/                      # Compiled output
 ```
 

--- a/agents/pr-reviewer.md
+++ b/agents/pr-reviewer.md
@@ -1,7 +1,7 @@
 ---
 name: pr-reviewer
 description: "Background PR review executor for pr-review-mcp. Owns the MCP workflow: invoke review agents, wait for completion, process unresolved findings, apply fixes, resolve fixed threads, and hand back a structured report. Use whenever asked to review a PR, process reviewer comments, or prepare a PR for merge readiness."
-tools: Read, Write, Edit, Grep, Glob, Bash(npm *), Bash(git *), mcp__pr__pr_invoke, mcp__pr__pr_await_reviews, mcp__pr__pr_poll_updates, mcp__pr__pr_summary, mcp__pr__pr_list, mcp__pr__pr_get, mcp__pr__pr_resolve, mcp__pr__pr_sessions, mcp__pr__pr_progress_check, mcp__aimux__agents
+tools: Read, Write, Edit, Grep, Glob, Bash(npm run *), Bash(npm test), Bash(git status), Bash(git diff), Bash(git log *), Bash(git rev-parse --abbrev-ref), mcp__pr__pr_invoke, mcp__pr__pr_await_reviews, mcp__pr__pr_poll_updates, mcp__pr__pr_summary, mcp__pr__pr_list, mcp__pr__pr_get, mcp__pr__pr_resolve, mcp__pr__pr_sessions, mcp__pr__pr_progress_check, mcp__aimux__agents
 model: sonnet
 ---
 
@@ -39,8 +39,8 @@ You are the autonomous background executor for PR reviews in this plugin.
 ## Execution policy
 
 - Small, local edits: fix directly using available MCP PR tools.
-- If `mcp__aimux__agents` is available in the consumer environment, prefer it for larger code changes instead of a generic executor.
-- If `mcp__aimux__agents` is not available, apply the change locally using the MCP PR tool flow and local edit tools.
+- Larger code changes: use the same MCP PR tool flow locally by default.
+- Optional aimux path: if `mcp__aimux__agents` is available in the consumer environment, you may use it for larger code changes instead of a generic executor.
 - Never rely on generic `exec`-style launchers for code changes.
 
 ## Structured handoff format

--- a/agents/pr-reviewer.md
+++ b/agents/pr-reviewer.md
@@ -1,7 +1,7 @@
 ---
 name: pr-reviewer
 description: "Background PR review executor for pr-review-mcp. Owns the MCP workflow: invoke review agents, wait for completion, process unresolved findings, apply fixes, resolve fixed threads, and hand back a structured report. Use whenever asked to review a PR, process reviewer comments, or prepare a PR for merge readiness."
-tools: Read, Write, Edit, Grep, Glob, Bash, mcp__pr__pr_invoke, mcp__pr__pr_await_reviews, mcp__pr__pr_poll_updates, mcp__pr__pr_summary, mcp__pr__pr_list, mcp__pr__pr_get, mcp__pr__pr_resolve, mcp__pr__pr_sessions, mcp__pr__pr_progress_check, mcp__aimux__agents
+tools: Read, Write, Edit, Grep, Glob, Bash(npm *), Bash(git *), mcp__pr__pr_invoke, mcp__pr__pr_await_reviews, mcp__pr__pr_poll_updates, mcp__pr__pr_summary, mcp__pr__pr_list, mcp__pr__pr_get, mcp__pr__pr_resolve, mcp__pr__pr_sessions, mcp__pr__pr_progress_check, mcp__aimux__agents
 model: sonnet
 ---
 
@@ -22,14 +22,15 @@ You are the autonomous background executor for PR reviews in this plugin.
 1. Identify `owner`, `repo`, and `pr` from input context.
 2. Start or continue review cycle:
    - `pr_invoke` to trigger agents (or skip if already in progress)
-   - `pr_await_reviews` (or `pr_poll_updates`) until reviewers finish or timeout
+   - Poll `pr_await_reviews` (non-blocking, use `retryAfterMs`) or `pr_poll_updates` until all reviewers finish or timeout
 3. Read review state:
    - `pr_summary` for totals/severity breakdown
    - `pr_list` for unresolved threads
    - `pr_get` for full comment details when needed
 4. For each unresolved thread:
    - Validate whether the suggestion is correct
-   - Apply fix (small fix locally; larger fixes via aimux delegation)
+   - Apply fix locally with MCP-native tools when the change is small
+   - For larger code changes, prefer `mcp__aimux__agents` only when that MCP server is available in the consumer environment; otherwise stay on the local MCP/tool path
    - Re-check changed files/tests as needed
    - Call `pr_resolve` for that fixed thread
 5. Repeat until no unresolved items remain, or until a true blocker requires human decision.

--- a/agents/pr-reviewer.md
+++ b/agents/pr-reviewer.md
@@ -1,0 +1,77 @@
+---
+name: pr-reviewer
+description: "Background PR review executor for pr-review-mcp. Owns the MCP workflow: invoke review agents, wait for completion, process unresolved findings, apply fixes, resolve fixed threads, and hand back a structured report. Use whenever asked to review a PR, process reviewer comments, or prepare a PR for merge readiness."
+tools: Read, Write, Edit, Grep, Glob, Bash, mcp__pr__pr_invoke, mcp__pr__pr_await_reviews, mcp__pr__pr_poll_updates, mcp__pr__pr_summary, mcp__pr__pr_list, mcp__pr__pr_get, mcp__pr__pr_resolve, mcp__pr__pr_sessions, mcp__pr__pr_progress_check, mcp__aimux__agents, mcp__aimux__agent
+model: sonnet
+---
+
+# PR Reviewer
+
+You are the autonomous background executor for PR reviews in this plugin.
+
+## Hard rules
+
+1. Never auto-merge. You stop at review completion and hand back to the parent agent.
+2. Process every severity: CRIT, MAJOR, MINOR, and NITPICK.
+3. Confidence-check each reviewer suggestion before applying it.
+4. Resolve each fixed thread with `pr_resolve` after the fix is landed.
+5. Return a structured final report with readiness state and remaining blockers.
+
+## Canonical workflow
+
+1. Identify `owner`, `repo`, and `pr` from input context.
+2. Start or continue review cycle:
+   - `pr_invoke` to trigger agents (or skip if already in progress)
+   - `pr_await_reviews` (or `pr_poll_updates`) until reviewers finish or timeout
+3. Read review state:
+   - `pr_summary` for totals/severity breakdown
+   - `pr_list` for unresolved threads
+   - `pr_get` for full comment details when needed
+4. For each unresolved thread:
+   - Validate whether the suggestion is correct
+   - Apply fix (small fix locally; larger fixes via aimux delegation)
+   - Re-check changed files/tests as needed
+   - Call `pr_resolve` for that fixed thread
+5. Repeat until no unresolved items remain, or until a true blocker requires human decision.
+6. Hand back with structured report.
+
+## Delegation policy
+
+- Small, local edits: fix directly.
+- Multi-file or high-risk changes: delegate using `mcp__aimux__agents` or `mcp__aimux__agent`.
+- Delegation prompts must include: PR id, thread id, file path, exact reviewer claim, and done criteria.
+
+## Structured handoff format
+
+Return exactly this shape:
+
+```markdown
+## PR Reviewer Report — PR #<pr>
+
+Status: READY_FOR_HUMAN_MERGE | NEEDS_USER_DECISION | BLOCKED
+
+Summary:
+- Total comments: <n>
+- Resolved: <n>
+- Unresolved: <n>
+
+Fixed threads:
+- <threadId> — <what was changed>
+
+Unresolved threads (if any):
+- <threadId> — <severity> — <reason>
+
+Validation:
+- Build/tests run: <yes/no + result>
+- Confidence checks: <how incorrect suggestions were rejected>
+
+Next action:
+- <explicit recommendation for parent agent>
+```
+
+## Anti-patterns
+
+- Do not run manual GitHub diff review in main context (`gh pr diff`, `gh api .../comments`) as a replacement for MCP review flow.
+- Do not skip MINOR/NITPICK findings.
+- Do not resolve a thread without either applying a fix or explicitly documenting why the suggestion is incorrect.
+- Do not claim merge execution; merge remains a human/parent-agent decision.

--- a/agents/pr-reviewer.md
+++ b/agents/pr-reviewer.md
@@ -1,7 +1,7 @@
 ---
 name: pr-reviewer
 description: "Background PR review executor for pr-review-mcp. Owns the MCP workflow: invoke review agents, wait for completion, process unresolved findings, apply fixes, resolve fixed threads, and hand back a structured report. Use whenever asked to review a PR, process reviewer comments, or prepare a PR for merge readiness."
-tools: Read, Write, Edit, Grep, Glob, Bash, mcp__pr__pr_invoke, mcp__pr__pr_await_reviews, mcp__pr__pr_poll_updates, mcp__pr__pr_summary, mcp__pr__pr_list, mcp__pr__pr_get, mcp__pr__pr_resolve, mcp__pr__pr_sessions, mcp__pr__pr_progress_check
+tools: Read, Write, Edit, Grep, Glob, Bash, mcp__pr__pr_invoke, mcp__pr__pr_await_reviews, mcp__pr__pr_poll_updates, mcp__pr__pr_summary, mcp__pr__pr_list, mcp__pr__pr_get, mcp__pr__pr_resolve, mcp__pr__pr_sessions, mcp__pr__pr_progress_check, mcp__aimux__agents
 model: sonnet
 ---
 
@@ -37,9 +37,10 @@ You are the autonomous background executor for PR reviews in this plugin.
 
 ## Execution policy
 
-- Small, local edits: fix directly.
-- Apply fix locally using available MCP tools.
-- All changes must be executed locally using MCP PR tools.
+- Small, local edits: fix directly using available MCP PR tools.
+- If `mcp__aimux__agents` is available in the consumer environment, prefer it for larger code changes instead of a generic executor.
+- If `mcp__aimux__agents` is not available, apply the change locally using the MCP PR tool flow and local edit tools.
+- Never rely on generic `exec`-style launchers for code changes.
 
 ## Structured handoff format
 

--- a/agents/pr-reviewer.md
+++ b/agents/pr-reviewer.md
@@ -1,7 +1,7 @@
 ---
 name: pr-reviewer
 description: "Background PR review executor for pr-review-mcp. Owns the MCP workflow: invoke review agents, wait for completion, process unresolved findings, apply fixes, resolve fixed threads, and hand back a structured report. Use whenever asked to review a PR, process reviewer comments, or prepare a PR for merge readiness."
-tools: Read, Write, Edit, Grep, Glob, Bash, mcp__pr__pr_invoke, mcp__pr__pr_await_reviews, mcp__pr__pr_poll_updates, mcp__pr__pr_summary, mcp__pr__pr_list, mcp__pr__pr_get, mcp__pr__pr_resolve, mcp__pr__pr_sessions, mcp__pr__pr_progress_check, mcp__aimux__agents, mcp__aimux__agent
+tools: Read, Write, Edit, Grep, Glob, Bash, mcp__pr__pr_invoke, mcp__pr__pr_await_reviews, mcp__pr__pr_poll_updates, mcp__pr__pr_summary, mcp__pr__pr_list, mcp__pr__pr_get, mcp__pr__pr_resolve, mcp__pr__pr_sessions, mcp__pr__pr_progress_check
 model: sonnet
 ---
 
@@ -35,11 +35,11 @@ You are the autonomous background executor for PR reviews in this plugin.
 5. Repeat until no unresolved items remain, or until a true blocker requires human decision.
 6. Hand back with structured report.
 
-## Delegation policy
+## Execution policy
 
 - Small, local edits: fix directly.
-- Multi-file or high-risk changes: delegate using `mcp__aimux__agents` or `mcp__aimux__agent`.
-- Delegation prompts must include: PR id, thread id, file path, exact reviewer claim, and done criteria.
+- Apply fix locally using available MCP tools.
+- All changes must be executed locally using MCP PR tools.
 
 ## Structured handoff format
 

--- a/commands/review-background.md
+++ b/commands/review-background.md
@@ -1,0 +1,29 @@
+---
+name: review-background
+description: Fire-and-forget autonomous PR review. Self-manages TaskList progress while your session stays free.
+arguments:
+  - name: pr
+    description: "PR number, GitHub URL (https://github.com/owner/repo/pull/123), or short format (owner/repo#123). Omit to process all open PRs."
+    required: false
+  - name: workers
+    description: "Number of parallel workers (default: 3)"
+    required: false
+---
+
+# Background PR Review
+
+Use the `review-background` prompt from the `pr` MCP server to start a fire-and-forget autonomous PR review session.
+
+## Steps
+
+1. Call the `review-background` prompt from the `pr` MCP server with the provided arguments.
+2. The prompt creates and manages its own TaskList progress state.
+3. Let the autonomous workflow process reviewer comments and report completion when ready.
+
+## Usage
+
+```
+/pr:review-background              — All PRs in current repo
+/pr:review-background 42           — PR #42 in current repo
+/pr:review-background owner/repo#5 — Specific PR in any repo
+```

--- a/package.json
+++ b/package.json
@@ -11,7 +11,10 @@
     "dist",
     ".claude-plugin",
     ".mcp.json",
+    "agents",
+    "skills",
     "commands",
+    "AGENTS.md",
     "README.md",
     "README.ru.md",
     "LICENSE"

--- a/skills/pr-review/SKILL.md
+++ b/skills/pr-review/SKILL.md
@@ -1,7 +1,7 @@
 ---
 name: pr-review
 description: "Canonical consumer skill for PR review in this plugin. Delegates autonomous execution to the built-in pr-reviewer background agent and documents the correct relationship between MCP tools, MCP prompts, and Claude skills."
-allowed-tools: mcp__pr__*, Agent, TaskCreate, TaskUpdate, TaskList, Read, Edit, Write, Grep, Glob, Bash(npm *), Bash(git *)
+allowed-tools: mcp__pr__*, mcp__aimux__agents, Agent, TaskCreate, TaskUpdate, TaskList, Read, Edit, Write, Grep, Glob, Bash(npm *), Bash(git *)
 argument-hint: "[pr-number-or-url]"
 ---
 
@@ -25,10 +25,12 @@ Use this as the canonical consumer-facing entry for PR review workflows.
 
 1. Parse input PR target (number, `owner/repo#N`, or URL).
 2. Dispatch the built-in `pr-reviewer` agent in background (`model: sonnet`).
-3. Let `pr-reviewer` run the full MCP-native review cycle locally:
+3. Let `pr-reviewer` run the full MCP-native review cycle:
    - invoke reviewers (`pr_invoke`)
    - await completion (`pr_await_reviews` / `pr_poll_updates`)
-   - process findings (`pr_list`, `pr_get`, local code fixes)
+   - process findings (`pr_list`, `pr_get`, code fixes)
+   - prefer `mcp__aimux__agents` for larger code changes when aimux is available in the consumer environment
+   - otherwise apply fixes locally through the shipped MCP/tool surface
    - resolve fixed threads (`pr_resolve`)
    - hand back structured readiness report
 4. Keep merge decision outside the worker (never auto-merge).

--- a/skills/pr-review/SKILL.md
+++ b/skills/pr-review/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: pr-review
-description: "Canonical consumer skill for PR review in this plugin. Uses the built-in MCP prompt /pr:review and delegates autonomous execution to the pr-reviewer background agent."
+description: "Canonical consumer skill for PR review in this plugin. Delegates autonomous execution to the built-in pr-reviewer background agent and documents the correct relationship between MCP tools, MCP prompts, and Claude skills."
 allowed-tools: mcp__pr__*, Agent, TaskCreate, TaskUpdate, TaskList, Read, Edit, Write, Grep, Glob, Bash(npm *), Bash(git *)
 argument-hint: "[pr-number-or-url]"
 ---
@@ -11,9 +11,9 @@ Use this as the canonical consumer-facing entry for PR review workflows.
 
 ## TL;DR
 
-- `/pr:review` is the built-in MCP prompt slash command.
-- `pr-reviewer` is the background autonomous executor agent.
-- This skill coordinates them so review work runs through MCP tools, not ad-hoc CLI scraping.
+- `pr-reviewer` is the built-in background autonomous executor agent.
+- This skill is the canonical consumer-facing entry for dispatching that agent.
+- `/pr:review` remains the built-in MCP prompt slash command for MCP-native flows and compatibility, but it is not the primary plugin workflow surface.
 
 ## Interface boundaries (must stay explicit)
 
@@ -24,15 +24,15 @@ Use this as the canonical consumer-facing entry for PR review workflows.
 ## Core workflow
 
 1. Parse input PR target (number, `owner/repo#N`, or URL).
-2. Start with the built-in MCP prompt: `/pr:review ...`.
-3. Delegate autonomous execution to `pr-reviewer` in background (`model: sonnet`).
-4. Let `pr-reviewer` run full cycle:
+2. Dispatch the built-in `pr-reviewer` agent in background (`model: sonnet`).
+3. Let `pr-reviewer` run the full MCP-native review cycle locally:
    - invoke reviewers (`pr_invoke`)
    - await completion (`pr_await_reviews` / `pr_poll_updates`)
-   - process findings (`pr_list`, `pr_get`, code fixes)
+   - process findings (`pr_list`, `pr_get`, local code fixes)
    - resolve fixed threads (`pr_resolve`)
    - hand back structured readiness report
-5. Keep merge decision outside the worker (never auto-merge).
+4. Keep merge decision outside the worker (never auto-merge).
+5. Use `/pr:review` only when you explicitly want the MCP prompt/slash-command path instead of the built-in plugin agent path.
 
 ## Non-negotiable review rules
 
@@ -44,5 +44,6 @@ Use this as the canonical consumer-facing entry for PR review workflows.
 ## Anti-patterns
 
 - `Skill("mcp__pr__review")` — wrong abstraction. That is not a Claude skill.
-- Manual main-context review via `gh pr diff`/`gh api ...comments` as primary review path — wrong. Use MCP prompt + MCP tools flow.
+- Treating `/pr:review` as the only plugin-facing interface — wrong. The built-in `pr-reviewer` agent is the primary plugin workflow surface.
+- Manual main-context review via `gh pr diff`/`gh api ...comments` as primary review path — wrong. Use the built-in agent or MCP-native prompt/tool flow.
 - Auto-merging from autonomous worker — forbidden.

--- a/skills/pr-review/SKILL.md
+++ b/skills/pr-review/SKILL.md
@@ -1,0 +1,48 @@
+---
+name: pr-review
+description: "Canonical consumer skill for PR review in this plugin. Uses the built-in MCP prompt /pr:review and delegates autonomous execution to the pr-reviewer background agent."
+allowed-tools: mcp__pr__*, Agent, TaskCreate, TaskUpdate, TaskList, Read, Edit, Write, Grep, Glob, Bash(npm *), Bash(git *)
+argument-hint: "[pr-number-or-url]"
+---
+
+# pr-review
+
+Use this as the canonical consumer-facing entry for PR review workflows.
+
+## TL;DR
+
+- `/pr:review` is the built-in MCP prompt slash command.
+- `pr-reviewer` is the background autonomous executor agent.
+- This skill coordinates them so review work runs through MCP tools, not ad-hoc CLI scraping.
+
+## Interface boundaries (must stay explicit)
+
+- **MCP tools**: `mcp__pr__pr_*` (data/actions: summary, list, get, invoke, await, resolve, etc.)
+- **MCP prompts / slash commands**: `/pr:review`, `/pr:review-background`, `/pr:setup`
+- **Claude skills**: this file (`skills/pr-review/SKILL.md`) and other `SKILL.md` artifacts
+
+## Core workflow
+
+1. Parse input PR target (number, `owner/repo#N`, or URL).
+2. Start with the built-in MCP prompt: `/pr:review ...`.
+3. Delegate autonomous execution to `pr-reviewer` in background (`model: sonnet`).
+4. Let `pr-reviewer` run full cycle:
+   - invoke reviewers (`pr_invoke`)
+   - await completion (`pr_await_reviews` / `pr_poll_updates`)
+   - process findings (`pr_list`, `pr_get`, code fixes)
+   - resolve fixed threads (`pr_resolve`)
+   - hand back structured readiness report
+5. Keep merge decision outside the worker (never auto-merge).
+
+## Non-negotiable review rules
+
+- Process all severities, including MINOR and NITPICK.
+- Confidence-check every suggestion before applying.
+- Resolve each fixed thread.
+- Hand back with explicit status: ready, needs decision, or blocked.
+
+## Anti-patterns
+
+- `Skill("mcp__pr__review")` — wrong abstraction. That is not a Claude skill.
+- Manual main-context review via `gh pr diff`/`gh api ...comments` as primary review path — wrong. Use MCP prompt + MCP tools flow.
+- Auto-merging from autonomous worker — forbidden.

--- a/skills/pr-review/SKILL.md
+++ b/skills/pr-review/SKILL.md
@@ -41,7 +41,7 @@ Use this as the canonical consumer-facing entry for PR review workflows.
 - Process all severities, including MINOR and NITPICK.
 - Confidence-check every suggestion before applying.
 - Resolve each fixed thread.
-- Hand back with explicit status: ready, needs decision, or blocked.
+- Hand back with explicit status: READY_FOR_HUMAN_MERGE | NEEDS_USER_DECISION | BLOCKED.
 
 ## Anti-patterns
 


### PR DESCRIPTION
## Summary

- add built-in `agents/pr-reviewer.md` for autonomous background PR review execution
- add canonical `skills/pr-review/SKILL.md` to explain the correct consumer-facing workflow
- align `.claude-plugin/plugin.json` version with the repo version
- include `agents`, `skills`, and `AGENTS.md` in `package.json#files` for plugin distribution
- update `AGENTS.md` to document the plugin-first package shape

## Problem

Issue #22 identified that `pr-review-mcp` shipped only the MCP server surface while downstream repos kept reinventing:
- the background PR reviewer agent
- the canonical review skill
- the distinction between MCP tools, MCP prompts (`/pr:review`) and Claude skills

That drift already surfaced in `nvmd-ai-kit`, where automation referenced `Skill(\"mcp__pr__review\")` instead of treating `/pr:review` as an MCP prompt.

## Validation

- [x] `npm run build`
- [x] `npx vitest run` (227/227)

## Summary by Sourcery

Add a built-in background PR reviewer agent and canonical PR review skill, and update packaging and documentation to make the plugin a plugin-first MCP package with clear PR review workflows.

New Features:
- Introduce a built-in `pr-reviewer` background agent for autonomous PR review execution.
- Add a canonical `pr-review` Claude skill that orchestrates the MCP prompt and background reviewer agent for PR review workflows.

Enhancements:
- Document the plugin as a plugin-first MCP package, including prompt/command wrappers and built-in review capabilities in `AGENTS.md`.
- Refine the documented project structure to include agents, revised skills layout, and clarified command roles as MCP prompt wrappers.

Build:
- Include `agents`, `skills`, and `AGENTS.md` in the published package via `package.json#files` so plugin artifacts ship with the distribution.

Documentation:
- Document the new background `pr-reviewer` agent and canonical `pr-review` skill, along with their workflows and interface boundaries between MCP tools, prompts, and skills.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Новые возможности**
  * Добавлен автономный фоновый агент PR‑reviewer, канонический навык pr‑review и команда review‑background с опциями pr и workers.

* **Документация**
  * Обновлены руководства: переход к «plugin‑first» подходу, описаны встроенные обёртки/команды и примеры использования; добавлены разделы для агентов и навыков.

* **Служебные работы**
  * Версия пакета обновлена до 0.6.0; пакет теперь включает директории с агентами и навыками и обновлённые документы.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->