### PR TITLE
fix: restore local dev MCP startup config

### DIFF
--- a/.mcp.json
+++ b/.mcp.json
@@ -2,10 +2,7 @@
   "mcpServers": {
     "pr": {
       "command": "node",
-      "args": ["${CLAUDE_PLUGIN_ROOT}/dist/index.js"],
-      "env": {
-        "GITHUB_PERSONAL_ACCESS_TOKEN": "${GITHUB_PERSONAL_ACCESS_TOKEN}"
-      }
+      "args": ["dist/index.js"]
     }
   }
 }


### PR DESCRIPTION
## Summary

- switch project-level `.mcp.json` back to a local debug command
- use `node dist/index.js` instead of `${CLAUDE_PLUGIN_ROOT}/dist/index.js`
- preserve plugin packaging via `.claude-plugin/plugin.json`

## Why

The plugin manifest should keep `${CLAUDE_PLUGIN_ROOT}` for consumer installs, but the repo-local `.mcp.json` is used for local debugging inside this repository. Using the plugin-root placeholder there breaks `/mcp` reconnect during local development.

## Verification

- [x] `npm ci`
- [x] `npm run build`

## Summary by Sourcery

Enhancements:
- Adjust local .mcp.json to run the built CLI via a direct node command suitable for in-repo debugging while leaving consumer plugin packaging behavior unchanged.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Обновлена конфигурация сервера для оптимизации пути выполнения.
  * Упрощена обработка переменных окружения.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->