### PR TITLE
fix: remove npm self-upgrade from publish workflow

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -18,8 +18,6 @@ jobs:
         with:
           node-version: '22'
 
-      - run: npm install -g npm@latest
-
       - run: npm ci
 
       - run: npm run build


### PR DESCRIPTION
## Summary

- remove `npm install -g npm@latest` from `.github/workflows/publish.yml`
- keep the workflow on the npm bundled with `actions/setup-node`

## Problem

The `Publish to npm` workflow for `v0.6.0` failed before `npm ci` with:

- `MODULE_NOT_FOUND`
- `Cannot find module 'promise-retry'`

The failure came from the self-upgrade step itself, not from the package build or publish logic.

## Validation

- workflow diff reviewed locally
- fix is minimal and removes only the failing step

## Summary by Sourcery

CI:
- Simplify the publish workflow by removing the global npm@latest installation step that caused failures before npm ci.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Обслуживание
* Оптимизирован конвейер развертывания за счет использования встроенной версии npm, поставляемой с Node.js, вместо отдельной глобальной установки.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->