### PR TITLE
fix: wire npm token into publish workflow

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -17,9 +17,12 @@ jobs:
       - uses: actions/setup-node@v4
         with:
           node-version: '22'
+          registry-url: 'https://registry.npmjs.org'
 
       - run: npm ci
 
       - run: npm run build
 
       - run: npm publish --provenance --access public
+        env:
+          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}


### PR DESCRIPTION
## Summary

- configure `actions/setup-node` with the npm registry URL
- pass `NODE_AUTH_TOKEN` from `secrets.NPM_TOKEN` to `npm publish`

## Problem

After removing the broken npm self-upgrade step, the publish workflow still failed on release runs with:
- `ENEEDAUTH`
- `This command requires you to be logged in to https://registry.npmjs.org/`

The job was building successfully; it simply had no npm authentication wired into the publish step.

## Validation

- workflow diff reviewed locally
- change is limited to authentication wiring for publish step

## Summary by Sourcery

CI:
- Configure actions/setup-node with the npm registry URL and pass NODE_AUTH_TOKEN from NPM_TOKEN secret to the npm publish step.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Выпуск

* **Chores**
  * Обновлена конфигурация процесса публикации пакета с улучшенной аутентификацией и явным указанием реестра npm для повышения надежности и безопасности при развертывании.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->