### PR TITLE
fix: use trusted publishing flow for npm release job

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -24,5 +24,3 @@ jobs:
       - run: npm run build
 
       - run: npm publish --provenance --access public
-        env:
-          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}


### PR DESCRIPTION
## Summary

- remove `NODE_AUTH_TOKEN` wiring from the publish workflow
- rely on npm trusted publishing (OIDC) instead of token auth

## Problem

After PR #32, the publish job still failed because `NODE_AUTH_TOKEN` was empty at runtime.
That forced npm into token-auth mode and produced `ENEEDAUTH`, even though the package is already configured as a trusted publisher on npm.

## Validation

- workflow diff reviewed locally
- fix is limited to removing the incorrect token path

## Summary by Sourcery

CI:
- Remove NODE_AUTH_TOKEN configuration from the npm publish workflow to allow OIDC-based trusted publishing to work correctly.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Chores

* Обновлена конфигурация рабочего процесса публикации пакета; аутентификация теперь выполняется на основе встроенных настроек окружения вместо явной передачи учетных данных в процесс публикации.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->