### PR TITLE
fix: pin supported Node/npm toolchain for trusted publishing

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -16,8 +16,12 @@ jobs:
 
       - uses: actions/setup-node@v4
         with:
-          node-version: '22'
+          node-version: '22.14.0'
           registry-url: 'https://registry.npmjs.org'
+
+      - run: npm install -g npm@11.10.0
+
+      - run: node -v && npm -v
 
       - run: npm ci
 


### PR DESCRIPTION
## Summary

- pin `actions/setup-node` to `22.14.0`
- upgrade npm in CI to `11.10.0`
- print `node -v && npm -v` before publish

## Why

The current trusted-publishing flow still fails with a misleading `E404` after provenance signing. This PR tests the hypothesis that the publish runner toolchain is too old for current npm trusted publishing expectations.

## Validation

- workflow-only change
- no application code modified

## Summary by Sourcery

Pin the Node.js version and npm toolchain used by the publish workflow to specific versions and log them before running the publish steps.

CI:
- Update the publish workflow to use Node.js 22.14.0 with actions/setup-node and globally install npm 11.10.0 before running CI steps.
- Add a step to print the Node and npm versions in the publish workflow for easier debugging of the trusted publishing environment.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Служебные изменения**
  * Оптимизирован процесс автоматической сборки и публикации для повышения стабильности и надежности выпусков пакета.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->